### PR TITLE
(Fix) local start URL

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,5 @@
 {
-  "startURL" : "https://wizard.poa.network/",
+  "startURL" : "http://localhost:3000",
   "outputPath":"./results",
   "installMetaMask":true
-
 }


### PR DESCRIPTION
We need to start end to end tests by default on local deployment to test current update of wizard, that is not deployed yet.